### PR TITLE
Refactor and add callbacks to navigation functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Returns a new `Client` object. `options` include:
 
 * `uuid`: The uuid (Bluetooth UUID) or the Published Name (something like RS_XXXXXX) of the drone. Defaults to finding first announced.
 
-#### client.on('battery', callback) 
+#### client.on('battery', callback)
 
 Event that is emitted on battery change activity. Caution, battery drains pretty fast on this so this may create a high velocity of events.
 
@@ -123,37 +123,37 @@ reports that it is hovering.
 Sets the internal `fly` state to `false`, `callback` is invoked after the drone
 reports it has landed.
 
-#### client.up([options]) / client.down([options])
+#### client.up([options], [callback]) / client.down([options], [callback])
 
 Options
 
-> * `speed` at which the drive should occur. 0-100 values.
-> * `steps` the length of steps (time) the drive should happen. 0-100 values.
- 
-Makes the drone gain or reduce altitude. 
+> * `speed` at which the drive should occur, a number from 0 to 100 inclusive.
+> * `steps` the length of steps (time) the drive should happen, a number from 0 to 100 inclusive.
 
-#### client.clockwise([options]) / client.counterClockwise([options]) __or__ client.turnRight([options]) / client.turnLeft([options])
+Makes the drone gain or reduce altitude. `callback` is invoked after all the steps are completed.
+
+#### client.clockwise([options], [callback]) / client.counterClockwise([options], [callback]) __or__ client.turnRight([options], [callback]) / client.turnLeft([options], [callback])
 
 Options
 
 > * `speed` at which the rotation should occur
-> * `steps` the length of steps (time) the turning should happen. 0-100 values.
+> * `steps` the length of steps (time) the turning should happen, a number from 0 to 100 inclusive.
 
-Causes the drone to spin. 
+Causes the drone to spin. `callback` is invoked after all the steps are completed.
 
-#### client.forward([options]) / client.backward([optoins])
+#### client.forward([options], [callback]) / client.backward([options], [callback])
 
-> * `speed` at which the drive should occur. 0-100 values.
-> * `steps` the length of steps (time) the drive should happen. 0-100 values.
+> * `speed` at which the drive should occur, a number from 0 to 100 inclusive.
+> * `steps` the length of steps (time) the drive should happen, a number from 0 to 100 inclusive.
 
-Controls the pitch.
+Controls the pitch. `callback` is invoked after all the steps are completed.
 
-#### client.left([options]) / client.right([options]) __or__ client.tiltLeft([options]) / client.tiltRight([options])
+#### client.left([options], [callback]) / client.right([options], [callback]) __or__ client.tiltLeft([options], [callback]) / client.tiltRight([options], [callback])
 
-> * `speed` at which the drive should occur. 0-100 values.
-> * `steps` the length of steps (time) the drive should happen. 0-100 values.
+> * `speed` at which the drive should occur, a number from 0 to 100 inclusive.
+> * `steps` the length of steps (time) the drive should happen, a number from 0 to 100 inclusive.
 
-Controls the roll, which is a horizontal movement.
+Controls the roll, which is a horizontal movement. `callback` is invoked after all the steps are completed.
 
 #### client.frontFlip()
 

--- a/lib/drone.js
+++ b/lib/drone.js
@@ -377,6 +377,7 @@ Drone.prototype.startPing = function () {
       this.driveStepsRemaining--;
     } else {
       // reset to hover states
+      this.emit('driveComplete', this.speeds);
       this.driveStepsRemaining = 0;
       this.hover();
     }
@@ -617,7 +618,7 @@ function leftFlip() {
  * @param {float} speed at which the drive should occur
  * @param {float} steps the length of steps (time) the drive should happen
  */
-function up(options) {
+function up(options, callback) {
   this.logger('RollingSpider#up');
   if (this.status.flying) {
     options = options || {};
@@ -627,6 +628,7 @@ function up(options) {
       this.logger('RollingSpider#up was called with an invalid speed: ' + speed);
     } else {
       this.drive(0, 0, 0, speed, steps);
+      this.once('driveComplete', callback);
     }
   } else {
     this.logger('RollingSpider#up when when it\'s not in the air isn\'t going to do anything');
@@ -641,7 +643,7 @@ function up(options) {
  * @param {float} steps the length of steps (time) the drive should happen
  */
 
-function down(options) {
+function down(options, callback) {
   this.logger('RollingSpider#down');
   if (this.status.flying) {
     options = options || {};
@@ -651,6 +653,7 @@ function down(options) {
       this.logger('RollingSpider#down was called with an invalid speed: ' + speed);
     } else {
       this.drive(0, 0, 0, speed * -1, steps);
+      this.once('driveComplete', callback);
     }
   } else {
     this.logger('RollingSpider#down when when it\'s not in the air isn\'t going to do anything');
@@ -663,7 +666,7 @@ function down(options) {
  * @param {float} speed at which the drive should occur. 0-100 values.
  * @param {float} steps the length of steps (time) the drive should happen
  */
-function forward(options) {
+function forward(options, callback) {
   this.logger('RollingSpider#forward');
   if (this.status.flying) {
     options = options || {};
@@ -673,6 +676,7 @@ function forward(options) {
       this.logger('RollingSpider#forward was called with an invalid speed: ' + speed);
     } else {
       this.drive(0, speed, 0, 0, steps);
+      this.once('driveComplete', callback);
     }
   } else {
     this.logger('RollingSpider#forward when it\'s not in the air isn\'t going to do anything');
@@ -686,7 +690,7 @@ function forward(options) {
  * @param {float} speed at which the drive should occur
  * @param {float} steps the length of steps (time) the drive should happen
  */
-function backward(options) {
+function backward(options, callback) {
   this.logger('RollingSpider#backward');
   if (this.status.flying) {
     options = options || {};
@@ -696,6 +700,7 @@ function backward(options) {
       this.logger('RollingSpider#backward was called with an invalid speed: ' + speed);
     } else {
       this.drive(0, speed * -1, 0, 0, steps);
+      this.once('driveComplete', callback);
     }
   } else {
     this.logger('RollingSpider#up when it\'s not in the air isn\'t going to do anything');
@@ -711,7 +716,7 @@ function backward(options) {
  * @param {float} steps the length of steps (time) the turning should happen
  */
 
-function turnRight(options) {
+function turnRight(options, callback) {
   this.logger('RollingSpider#turnRight');
   options = options || {};
   var speed = options.speed || 50;
@@ -720,6 +725,7 @@ function turnRight(options) {
     this.logger('RollingSpider#turnRight was called with an invalid speed: ' + speed);
   } else {
     this.drive(0, 0, speed, 0, steps);
+    this.once('driveComplete', callback);
   }
 }
 
@@ -729,7 +735,7 @@ function turnRight(options) {
  * @param {float} speed at which the rotation should occur
  * @param {float} steps the length of steps (time) the turning should happen
  */
-function turnLeft(options) {
+function turnLeft(options, callback) {
   this.logger('RollingSpider#turnLeft');
   options = options || {};
   var speed = options.speed || 50;
@@ -738,6 +744,7 @@ function turnLeft(options) {
     this.logger('RollingSpider#turnLeft was called with an invalid speed: ' + speed);
   } else {
     this.drive(0, 0, speed * -1, 0, steps);
+    this.once('driveComplete', callback);
   }
 }
 
@@ -748,7 +755,7 @@ function turnLeft(options) {
  * @param {float} speed at which the rotation should occur
  * @param {float} steps the length of steps (time) the turning should happen
  */
-function tiltRight(options) {
+function tiltRight(options, callback) {
   this.logger('RollingSpider#tiltRight');
   options = options || {};
   var speed = options.speed || 50;
@@ -756,8 +763,8 @@ function tiltRight(options) {
   if (!validSpeed(speed)) {
     this.logger('RollingSpider#tiltRight was called with an invalid speed: ' + speed);
   } else {
-
     this.drive(speed, 0, 0, 0, steps);
+    this.once('driveComplete', callback);
   }
 }
 
@@ -768,7 +775,7 @@ function tiltRight(options) {
  * @param {float} speed at which the rotation should occur
  * @param {float} steps the length of steps (time) the turning should happen
  */
-function tiltLeft(options) {
+function tiltLeft(options, callback) {
   this.logger('RollingSpider#tiltLeft');
   options = options || {};
   var speed = options.speed || 50;
@@ -778,6 +785,7 @@ function tiltLeft(options) {
     this.logger('RollingSpider#tiltLeft was called with an invalid speed: ' + speed);
   } else {
     this.drive(speed * -1, 0, 0, 0, steps);
+    this.once('driveComplete', callback);
   }
 }
 

--- a/lib/drone.js
+++ b/lib/drone.js
@@ -235,15 +235,22 @@ Drone.prototype.handshake = function (callback) {
     }
 
 
-    var prevState = this.status.flying;
+    var prevState = this.status.flying,
+        prevFlyingStatus = this.status.stateValue;
+
     if ([1, 2, 3, 4].indexOf(data[6]) >= 0) {
       this.status.flying = true;
     } else {
       this.status.flying = false;
     }
     this.status.stateValue = data[6];
+
     if (prevState !== this.status.flying) {
       this.emit('stateChange');
+    }
+
+    if (prevFlyingStatus !== this.status.stateValue) {
+      this.emit('flyingStatusChange', this.status.stateValue);
     }
 
   }.bind(this));
@@ -425,7 +432,7 @@ Drone.prototype.drive = function (tilt, forward, turn, up, steps) {
  *
  * @todo Make this detect when it's in the air and call a callback function
  */
-function takeOff() {
+function takeOff(callback) {
   this.logger('RollingSpider#takeOff');
   if (this.status.battery < 10) {
     this.logger('!!! BATTERY LEVEL TOO LOW !!!');
@@ -438,6 +445,11 @@ function takeOff() {
     this.status.flying = true;
   }
 
+  this.on('flyingStatusChange', function(newStatus) {
+    if (newStatus === 2) {
+      callback();
+    }
+  });
 }
 
 
@@ -473,13 +485,20 @@ function wheelOff() {
  * @todo Make this detect when it's landed and call a callback function
  */
 
-function land() {
+function land(callback) {
   this.logger('RollingSpider#land');
   if (this.status.flying) {
     this.writeTo(
       'fa0b',
       new Buffer([0x02, ++this.steps.fa0b & 0xFF, 0x02, 0x00, 0x03, 0x00])
       );
+
+    this.on('flyingStatusChange', function(newStatus) {
+      if (newStatus === 0) {
+        callback();
+      }
+    });
+
   } else {
     this.logger('Calling RollingSpider#land when it\'s not in the air isn\'t going to do anything');
   }

--- a/lib/drone.js
+++ b/lib/drone.js
@@ -7,6 +7,7 @@ var noble = require('noble');
 var debug = require('debug')('rollingspider');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
+var _ = require('lodash');
 
 
 
@@ -405,22 +406,19 @@ Drone.prototype.signalStrength = function (callback) {
   }
 };
 
-
-
-
-Drone.prototype.drive = function (tilt, forward, turn, up, steps) {
+Drone.prototype.drive = function(parameters, steps) {
   this.logger('RollingSpider#drive');
+  var params = parameters || {};
   if (!this.driveStepsRemaining) {
     // only apply when not driving currently, this causes you to exactly move -- prevents fluid
     this.driveStepsRemaining = steps || 1;
-    this.speeds.roll = tilt;
-    this.speeds.pitch = forward;
-    this.speeds.yaw = turn;
-    this.speeds.altitude = up;
+    this.speeds.roll = parameters.tilt || 0;
+    this.speeds.pitch = parameters.forward || 0;
+    this.speeds.yaw = parameters.turn || 0;
+    this.speeds.altitude = parameters.up || 0;
     // inject into ping flow.
   }
 };
-
 
 // Operational Functions
 // Multiple use cases provided to support initial build API as well as
@@ -430,8 +428,6 @@ Drone.prototype.drive = function (tilt, forward, turn, up, steps) {
 
 /**
  * Instructs the drone to take off if it isn't already in the air
- *
- * @todo Make this detect when it's in the air and call a callback function
  */
 function takeOff(callback) {
   this.logger('RollingSpider#takeOff');
@@ -481,9 +477,7 @@ function wheelOff() {
 }
 
 /**
- * Instructs the drone to land if it's in the air
- *
- * @todo Make this detect when it's landed and call a callback function
+ * Instructs the drone to land if it's in the air.
  */
 
 function land(callback) {
@@ -612,29 +606,54 @@ function leftFlip() {
   }
 }
 
+function driveBuilder(parameters) {
+  var name = parameters.name,
+      parameterToChange = parameters.parameterToChange,
+      scaleFactor = parameters.scaleFactor;
+
+  scaleFactor = scaleFactor || 1;
+
+  return function(possibleOptions, possibleCallback) {
+    var options, callback;
+    if (_.isPlainObject(possibleOptions)) {
+      options = possibleOptions;
+      callback = _.isFunction(possibleCallback) ? possibleCallback : _.noop;
+    } else if (_.isFunction(possibleOptions)) {
+      callback = possibleOptions;
+    } else {
+      callback = _.noop;
+    }
+
+    this.logger('RollingSpider#' + name);
+    if (this.status.flying) {
+      options = options || {};
+      var speed = options.speed || 50;
+      var steps = options.steps || 50;
+      if (!validSpeed(speed)) {
+        this.logger('RollingSpider#' + name + 'was called with an invalid speed: ' + speed);
+      } else {
+        var driveParams = {};
+        driveParams[parameterToChange] = speed * scaleFactor;
+        this.drive(driveParams, steps);
+        this.once('driveComplete', callback);
+      }
+    } else {
+      this.logger('RollingSpider#' + name  + ' when it\'s not in the air isn\'t going to do anything');
+    }
+  };
+
+}
+
 /**
  * Instructs the drone to start moving upward at speed
  *
  * @param {float} speed at which the drive should occur
  * @param {float} steps the length of steps (time) the drive should happen
  */
-function up(options, callback) {
-  this.logger('RollingSpider#up');
-  if (this.status.flying) {
-    options = options || {};
-    var speed = options.speed || 50;
-    var steps = options.steps || 50;
-    if (!validSpeed(speed)) {
-      this.logger('RollingSpider#up was called with an invalid speed: ' + speed);
-    } else {
-      this.drive(0, 0, 0, speed, steps);
-      this.once('driveComplete', callback);
-    }
-  } else {
-    this.logger('RollingSpider#up when when it\'s not in the air isn\'t going to do anything');
-  }
-
-}
+var up = driveBuilder({
+  name: 'up',
+  parameterToChange: 'up'
+});
 
 /**
  * Instructs the drone to start moving downward at speed
@@ -642,47 +661,23 @@ function up(options, callback) {
  * @param {float} speed at which the drive should occur
  * @param {float} steps the length of steps (time) the drive should happen
  */
+var down = driveBuilder({
+  name: 'down',
+  parameterToChange: 'up',
+  scaleFactor: -1
+});
 
-function down(options, callback) {
-  this.logger('RollingSpider#down');
-  if (this.status.flying) {
-    options = options || {};
-    var speed = options.speed || 50;
-    var steps = options.steps || 50;
-    if (!validSpeed(speed)) {
-      this.logger('RollingSpider#down was called with an invalid speed: ' + speed);
-    } else {
-      this.drive(0, 0, 0, speed * -1, steps);
-      this.once('driveComplete', callback);
-    }
-  } else {
-    this.logger('RollingSpider#down when when it\'s not in the air isn\'t going to do anything');
-  }
-
-}
 /**
  * Instructs the drone to start moving forward at speed
  *
  * @param {float} speed at which the drive should occur. 0-100 values.
  * @param {float} steps the length of steps (time) the drive should happen
  */
-function forward(options, callback) {
-  this.logger('RollingSpider#forward');
-  if (this.status.flying) {
-    options = options || {};
-    var speed = options.speed || 50;
-    var steps = options.steps || 50;
-    if (!validSpeed(speed)) {
-      this.logger('RollingSpider#forward was called with an invalid speed: ' + speed);
-    } else {
-      this.drive(0, speed, 0, 0, steps);
-      this.once('driveComplete', callback);
-    }
-  } else {
-    this.logger('RollingSpider#forward when it\'s not in the air isn\'t going to do anything');
-  }
+var forward = driveBuilder({
+  name: 'forward',
+  parameterToChange: 'forward'
+});
 
-}
 
 /**
  * Instructs the drone to start moving backward at speed
@@ -690,23 +685,11 @@ function forward(options, callback) {
  * @param {float} speed at which the drive should occur
  * @param {float} steps the length of steps (time) the drive should happen
  */
-function backward(options, callback) {
-  this.logger('RollingSpider#backward');
-  if (this.status.flying) {
-    options = options || {};
-    var speed = options.speed || 50;
-    var steps = options.steps || 50;
-    if (!validSpeed(speed)) {
-      this.logger('RollingSpider#backward was called with an invalid speed: ' + speed);
-    } else {
-      this.drive(0, speed * -1, 0, 0, steps);
-      this.once('driveComplete', callback);
-    }
-  } else {
-    this.logger('RollingSpider#up when it\'s not in the air isn\'t going to do anything');
-  }
-
-}
+var backward = driveBuilder({
+  name: 'backward',
+  parameterToChange: 'forward',
+  scaleFactor: -1
+});
 
 
 /**
@@ -715,19 +698,10 @@ function backward(options, callback) {
  * @param {float} speed at which the rotation should occur
  * @param {float} steps the length of steps (time) the turning should happen
  */
-
-function turnRight(options, callback) {
-  this.logger('RollingSpider#turnRight');
-  options = options || {};
-  var speed = options.speed || 50;
-  var steps = options.steps || 50;
-  if (!validSpeed(speed)) {
-    this.logger('RollingSpider#turnRight was called with an invalid speed: ' + speed);
-  } else {
-    this.drive(0, 0, speed, 0, steps);
-    this.once('driveComplete', callback);
-  }
-}
+var turnRight = driveBuilder({
+  name: 'turnRight',
+  parameterToChange: 'turn'
+});
 
 /**
  * Instructs the drone to start spinning counter-clockwise at speed
@@ -735,18 +709,11 @@ function turnRight(options, callback) {
  * @param {float} speed at which the rotation should occur
  * @param {float} steps the length of steps (time) the turning should happen
  */
-function turnLeft(options, callback) {
-  this.logger('RollingSpider#turnLeft');
-  options = options || {};
-  var speed = options.speed || 50;
-  var steps = options.steps || 50;
-  if (!validSpeed(speed)) {
-    this.logger('RollingSpider#turnLeft was called with an invalid speed: ' + speed);
-  } else {
-    this.drive(0, 0, speed * -1, 0, steps);
-    this.once('driveComplete', callback);
-  }
-}
+var turnLeft = driveBuilder({
+  name: 'turnLeft',
+  parameterToChange: 'turn',
+  scaleFactor: -1
+});
 
 
 /**
@@ -755,18 +722,10 @@ function turnLeft(options, callback) {
  * @param {float} speed at which the rotation should occur
  * @param {float} steps the length of steps (time) the turning should happen
  */
-function tiltRight(options, callback) {
-  this.logger('RollingSpider#tiltRight');
-  options = options || {};
-  var speed = options.speed || 50;
-  var steps = options.steps || 50;
-  if (!validSpeed(speed)) {
-    this.logger('RollingSpider#tiltRight was called with an invalid speed: ' + speed);
-  } else {
-    this.drive(speed, 0, 0, 0, steps);
-    this.once('driveComplete', callback);
-  }
-}
+var tiltRight = driveBuilder({
+  name: 'tiltRight',
+  parameterToChange: 'tilt'
+});
 
 
 /**
@@ -775,19 +734,11 @@ function tiltRight(options, callback) {
  * @param {float} speed at which the rotation should occur
  * @param {float} steps the length of steps (time) the turning should happen
  */
-function tiltLeft(options, callback) {
-  this.logger('RollingSpider#tiltLeft');
-  options = options || {};
-  var speed = options.speed || 50;
-  var steps = options.steps || 50;
-
-  if (!validSpeed(speed)) {
-    this.logger('RollingSpider#tiltLeft was called with an invalid speed: ' + speed);
-  } else {
-    this.drive(speed * -1, 0, 0, 0, steps);
-    this.once('driveComplete', callback);
-  }
-}
+var tiltLeft = driveBuilder({
+  name: 'tiltLeft',
+  parameterToChange: 'tilt',
+  scaleFactor: -1
+});
 
 function hover() {
   this.logger('RollingSpider#hover');
@@ -808,8 +759,6 @@ function hover() {
 function validSpeed(speed) {
   return (0 <= speed && speed <= 100);
 }
-
-
 
 
 // provide options for use case


### PR DESCRIPTION
This pull request

- refactors the navigational functions to use a builder function
- implements callbacks for the takeoff, landing, and navigational functions that are triggered upon the completion of those actions

The callbacks allow code similar to this to be written without the need for manual timeouts (using Q.js, and where `q` is a function that converts a callback-based function into a promise-based one).

```javascript
Q.spawn(function*() {
  yield q(drone.connect);
  yield q(drone.setup);
  drone.calibrate();
  drone.startPing();
  yield q(drone.takeoff);
  yield Q.delay(1000);
  yield q(drone.up);
  yield q(drone.down);
  yield q(drone.land);
});
```