### PR TITLE
Remove maxcomplexity limit from jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -59,6 +59,5 @@
   "quotmark": true,
   "maxparams": 5,
   "maxdepth": 3,
-  "maxstatements": 25,
-  "maxcomplexity": 6
+  "maxstatements": 25
 }


### PR DESCRIPTION
There is no point in restricting complexity if it's not going to be adhered to ;)