### PR TITLE
Drone.isDronePeripheral(peripheral) => true|false

### DIFF
--- a/eg/discover.js
+++ b/eg/discover.js
@@ -1,22 +1,18 @@
 'use strict';
 
+var Drone = require('../');
 var noble = require('noble');
 var knownDevices = [];
 
 noble.startScanning();
 
 noble.on('discover', function(peripheral) {
-  var localName = peripheral.advertisement.localName;
-  var manufacturerData = peripheral.advertisement.manufacturerData;
-
-  var droneName = localName && localName.indexOf('RS_') === 0;
-  var manufacturer = manufacturerData && manufacturerData.toString('hex') === '4300cf1900090100';
-  if (!droneName && !manufacturer) {
+  if (!Drone.isDronePeripheral(peripheral)) {
     return; // not a rolling spider
   }
 
   var details = {
-    name: localName,
+    name: peripheral.advertisement.localName,
     uuid: peripheral.uuid,
     rssi: peripheral.rssi
   };

--- a/lib/drone.js
+++ b/lib/drone.js
@@ -73,6 +73,30 @@ var Drone = function (options) {
 
 util.inherits(Drone, EventEmitter);
 
+/**
+ * Drone.isDronePeripheral
+ *
+ * Accepts a BLE peripheral object record and returns true|false
+ * if that record represents a Rolling Spider Drone or not.
+ *
+ * @param  {Object}  peripheral A BLE peripheral record
+ * @return {Boolean}
+ */
+Drone.isDronePeripheral = function(peripheral) {
+  if (!peripheral) {
+    return false;
+  }
+
+  var localName = peripheral.advertisement.localName;
+  var manufacturer = peripheral.advertisement.manufacturerData;
+
+  var localNameMatch = localName && localName.indexOf('RS_') === 0;
+  var manufacturerMatch = manufacturer && manufacturer.toString('hex') === '4300cf1900090100';
+
+  // Is true for EITHER an "RS_" name OR manufacturer code.
+  return localNameMatch || manufacturerMatch;
+};
+
 
 // create client helper function to match ar-drone
 Drone.createClient = function (options) {
@@ -91,11 +115,21 @@ Drone.prototype.connect = function (callback) {
     this.logger('RollingSpider finding: ' + this.targets.join(', '));
   }
 
-
   this.ble.on('discover', function (peripheral) {
     this.logger('RollingSpider.on(discover)');
     this.logger(peripheral);
+
+    var isFound = false;
     var connectedRun = false;
+    var matchType = 'Fuzzy';
+
+    // Peripheral specific
+    var localName = peripheral.advertisement.localName;
+    var uuid = peripheral.uuid;
+
+    // Is this peripheral a Parrot Rolling Spider?
+    var isDrone = Drone.isDronePeripheral(peripheral);
+
     var onConnected = function (error) {
       if (connectedRun) {
         return;
@@ -107,31 +141,32 @@ Drone.prototype.connect = function (callback) {
           callback(error);
         }
       } else {
-        this.logger('Connected to: ' + peripheral.advertisement.localName);
+        this.logger('Connected to: ' + localName);
         this.ble.stopScanning();
         this.connected = true;
         this.setup(callback);
       }
-
     }.bind(this);
 
-    this.logger(peripheral.advertisement.localName);
-    if (this.targets) {
-      this.logger(this.targets.indexOf(peripheral.uuid));
-      this.logger(this.targets.indexOf(peripheral.advertisement.localName));
-    }
-    if (!this.discovered) {
-      var localName = peripheral.advertisement.localName;
-      var manufacturerData = peripheral.advertisement.manufacturerData;
-      var localNameMatch = localName && localName.indexOf('RS_') === 0;
-      var manufacturerMatch = manufacturerData && manufacturerData.toString('hex') === '4300cf1900090100';
+    this.logger(localName);
 
-      if (this.targets && (this.targets.indexOf(peripheral.uuid) >= 0 || this.targets.indexOf(peripheral.advertisement.localName) >= 0)) {
-        this.logger('Exact match found: ' + peripheral.advertisement.localName + ' <' + peripheral.uuid + '>');
-        this.connectPeripheral(peripheral, onConnected);
-      } else if (((typeof this.targets) === 'undefined' || this.targets.length === 0) && (localNameMatch || manufacturerMatch)){
-        //found a rolling spider
-        this.logger('Fuzzy match found: ' + peripheral.advertisement.localName + ' <' + peripheral.uuid + '>');
+    if (this.targets) {
+      this.logger(this.targets.indexOf(uuid));
+      this.logger(this.targets.indexOf(localName));
+    }
+
+    if (!this.discovered) {
+
+      if (this.targets &&
+          (this.targets.indexOf(uuid) >= 0 || this.targets.indexOf(localName) >= 0)) {
+        matchType = 'Exact';
+        isFound = true;
+      } else if ((typeof this.targets === 'undefined' || this.targets.length === 0) && isDrone) {
+        isFound = true;
+      }
+
+      if (isFound) {
+        this.logger(matchType + ' match found: ' + localName + ' <' + uuid + '>');
         this.connectPeripheral(peripheral, onConnected);
       }
     }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-mocha-test": "^0.12.7",
     "keypress": "^0.2.1",
-    "mocha": "^2.2.5"
+    "mocha": "2.2.5",
+    "should": "6.0.3",
+    "sinon": "1.14.1"
   },
   "repository": {
     "type": "git",

--- a/test/drone.js
+++ b/test/drone.js
@@ -1,0 +1,43 @@
+var Drone = require('../');
+var should = require('should');
+var sinon = require('sinon');
+
+
+describe('Drone.isDronePeripheral', function() {
+
+  it('returns false if no peripheral record', function(done) {
+    should.equal(Drone.isDronePeripheral(), false);
+    done();
+  });
+
+  it('returns true if peripheral.advertisement.localName begins with "RS_"', function(done) {
+    var peripheral = {
+      advertisement: {
+        localName: 'RS_whatever'
+      }
+    };
+    should.equal(Drone.isDronePeripheral(peripheral), true);
+    done();
+  });
+
+  it('returns true if peripheral.advertisement.manufacturerData is correct', function(done) {
+    var peripheral = {
+      advertisement: {
+        manufacturerData: new Buffer([0x43, 0x00, 0xcf, 0x19, 0x00, 0x09, 0x01, 0x00])
+      }
+    };
+    should.equal(Drone.isDronePeripheral(peripheral), true);
+    done();
+  });
+
+  it('returns true if custom name, but peripheral.advertisement.manufacturerData is correct', function(done) {
+    var peripheral = {
+      advertisement: {
+        localName: 'ArachnaBot',
+        manufacturerData: new Buffer([0x43, 0x00, 0xcf, 0x19, 0x00, 0x09, 0x01, 0x00])
+      }
+    };
+    should.equal(Drone.isDronePeripheral(peripheral), true);
+    done();
+  });
+});


### PR DESCRIPTION
- Centralize peripheral record validation
- Includes tests
  - Note that sinon is not yet in use, but will be once more tests are added and `drone.ble` needs to be mocked and spied.




